### PR TITLE
typo: fix the statement of prop.poly_on_functions

### DIFF
--- a/P1-Polynomials.tex
+++ b/P1-Polynomials.tex
@@ -2000,7 +2000,7 @@ Below, we explain how.
 
 \begin{proposition} \label{prop.poly_on_functions}
 Let $p$ be an arbitrary polynomial functor (our notation allows us to write it as $p\iso\sum_{i\in p(\1)} \yon^{p[i]}$), and let $f\colon X\to Y$ be an arbitrary function.
-Then $p(f)\colon p(X)\to q(X)$ sends each $(i, g)\in p(X)$, with $i\in p(\1)$ and $g\colon p[i]\to X$, to $(i, g\then f)$ in $p(Y)$.
+Then $p(f)\colon p(X)\to p(Y)$ sends each $(i, g)\in p(X)$, with $i\in p(\1)$ and $g\colon p[i]\to X$, to $(i, g\then f)$ in $p(Y)$.
 \end{proposition}
 \begin{proof}
 For each $i\in p(\1)$, by \cref{def.representable}, the functor $\yon^{p[i]}$ sends $f$ to the function $f^{p[i]}\colon X^{p[i]}\to Y^{p[i]}$, the one that sends every $g\colon p[i]\to X$ to $g\then f\colon p[i]\to Y$.


### PR DESCRIPTION
To conform to the syntax introduced in the statement of the proposition, q(X) should be p(Y).